### PR TITLE
feature/stoptranscodesession

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	server1.SetUrl(os.Getenv("PLEX_URL"))
 	server1.SetToken(os.Getenv("PLEX_TOKEN"))
 
-	res, err := sessions.GetTranscodeSessions(server1)
+	res, err := sessions.StopTranscodeSession(server1, "")
 
 	if err != nil {
 		fmt.Println(err)

--- a/sessions/session.go
+++ b/sessions/session.go
@@ -69,3 +69,15 @@ func GetTranscodeSessions(s server.Server) (string, error) {
 		return body, nil
 	}
 }
+
+func StopTranscodeSession(s server.Server, sessionKey string) (string, error) {
+	url := s.GetUrl() + "/transcode/sessions/" + sessionKey
+	method := "DELETE"
+
+	body, err := request(url, method, s.GetToken())
+	if err != nil {
+		return "", err
+	} else {
+		return body, nil
+	}
+}


### PR DESCRIPTION
## What?
complete issue #6, add function StopTranscodeSession
## Why?
These changes allow users to prevent people from transcoding on there server saving cpu usage
## How?
from the sessions package call the StopTranscodeSession function and pass in the server struct with url and token and pass the transcode session key obtained from the GetTranscodeSessions function. Doing so will end the session for the user in about 30 seconds or so. 
## Testing?
No testing
## Screenshots?
No
## Anything else?
No